### PR TITLE
Add Self-update from GitHub

### DIFF
--- a/feedland-blogroll.php
+++ b/feedland-blogroll.php
@@ -7,6 +7,7 @@
  * Version:           0.0.3
  * Author:            WordPress.com Special Projects
  * Author URI:        https://wpspecialprojects.wordpress.com
+ * Update URI:        https://github.com/a8cteam51/feedland-blogroll
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain:       feedland-blogroll
@@ -19,6 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 require_once 'includes/settings.php';
+require_once 'includes/self-update.php';
 
 /**
  * Actions and shortcodes here

--- a/feedland-blogroll.php
+++ b/feedland-blogroll.php
@@ -4,7 +4,7 @@
  * Description:       Show a Blogroll on your site.
  * Requires at least: 6.1
  * Requires PHP:      7.4
- * Version:           0.0.3
+ * Version:           1.0.0
  * Author:            WordPress.com Special Projects
  * Author URI:        https://wpspecialprojects.wordpress.com
  * Update URI:        https://github.com/a8cteam51/feedland-blogroll

--- a/includes/self-update.php
+++ b/includes/self-update.php
@@ -4,12 +4,12 @@ add_filter( 'update_plugins_github.com', 'feedland_blogroll_self_update', 10, 4 
 /**
  * Check for updates to this plugin
  *
- * @param array  $update   Array of update data.
- * @param array  $plugin_data Array of plugin data.
- * @param string $plugin_file Path to plugin file.
- * @param string $locales    Locale code.
+ * @param array|false $update      Array of update data.
+ * @param array       $plugin_data Array of plugin data.
+ * @param string      $plugin_file Path to plugin file.
+ * @param string[]    $locales     Locale code.
  *
- * @return array|bool Array of update data or false if no update available.
+ * @return array|false Array of update data or false if no update available.
  */
 function feedland_blogroll_self_update( $update, array $plugin_data, string $plugin_file, $locales ) {
 

--- a/includes/self-update.php
+++ b/includes/self-update.php
@@ -1,0 +1,61 @@
+<?php
+add_filter( 'update_plugins_github.com', 'feedland_blogroll_self_update', 10, 4 );
+
+/**
+ * Check for updates to this plugin
+ *
+ * @param array  $update   Array of update data.
+ * @param array  $plugin_data Array of plugin data.
+ * @param string $plugin_file Path to plugin file.
+ * @param string $locales    Locale code.
+ *
+ * @return array|bool Array of update data or false if no update available.
+ */
+function feedland_blogroll_self_update( $update, array $plugin_data, string $plugin_file, $locales ) {
+
+	// only check this plugin
+	if ( 'feedland-blogroll/feedland-blogroll.php' !== $plugin_file ) {
+		return $update;
+	}
+
+	// already completed update check elsewhere
+	if ( ! empty( $update ) ) {
+		return $update;
+	}
+
+	// let's go get the latest version number from GitHub
+	$response = wp_remote_get(
+		'https://api.github.com/repos/a8cteam51/feedland-blogroll/releases/latest',
+		array(
+			'user-agent' => 'wpspecialprojects',
+		)
+	);
+
+	if ( is_wp_error( $response ) ) {
+		return;
+	} else {
+		$output = json_decode( wp_remote_retrieve_body( $response ), true );
+	}
+
+	$new_version_number  = $output['tag_name'];
+	$is_update_available = version_compare( $plugin_data['Version'], $new_version_number, '<' );
+
+	if ( ! $is_update_available ) {
+		return false;
+	}
+
+	$new_url     = $output['html_url'];
+	$new_package = $output['assets'][0]['browser_download_url'];
+
+	error_log('$plugin_data: ' . print_r( $plugin_data, true ));
+	error_log('$new_version_number: ' . $new_version_number );
+	error_log('$new_url: ' . $new_url );
+	error_log('$new_package: ' . $new_package );
+
+	return array(
+		'slug'    => $plugin_data['TextDomain'],
+		'version' => $new_version_number,
+		'url'     => $new_url,
+		'package' => $new_package,
+	);
+}


### PR DESCRIPTION
## Changes in the pull request

Adding the ability for the plugin to check for version updates directly from the public GitHub Repo.

### How this should work

After a new release is published:
1. When visiting the plugins page, the new release should show up as an available update
2. If autoupdates are turned on for this plugin, the plugin should autoupdate to the new release on the same schedule as all other plugin autoupdates (checks every 12 hours)

### Notes
- This only works if the plugin is loaded as `feedland-blogroll/feedland-blogroll.php`. If the plugin folder is named something different, like `feedland-blogroll(1)`, then this update feature will not work.
- This feature looks at the latest release version number, so proper releases and semVer should be used when new updates need to go out.