### PR TITLE
Update settings page

### DIFF
--- a/feedland-blogroll.php
+++ b/feedland-blogroll.php
@@ -27,7 +27,6 @@ define( 'FEEDLAND_BLOGROLL_PATH', plugin_dir_path( __FILE__ ) );
 
 define( 'FEEDLAND_DEFAULT_SERVER', 'https://feedland.social' );
 define( 'FEEDLAND_DEFAULT_USERNAME', 'davewiner' );
-define( 'FEEDLAND_DEFAULT_CATEGORY', 'blogroll' );
 
 require_once 'includes/settings.php';
 require_once 'includes/self-update.php';
@@ -193,7 +192,7 @@ function feedland_blogroll_default_options(): void {
 		'feedland_blogroll_flDisplayTitle'          => '1',
 		'feedland_blogroll_server'                  => FEEDLAND_DEFAULT_SERVER,
 		'feedland_blogroll_username'                => FEEDLAND_DEFAULT_USERNAME,
-		'feedland_blogroll_category'                => FEEDLAND_DEFAULT_CATEGORY,
+		'feedland_blogroll_category'                => '',
 		'feedland_blogroll_urlBlogrollOpml'         => feedland_get_opml_url(),
 		'feedland_blogroll_urlFeedlandViewBlogroll' => feedland_get_blogroll_url(),
 	);
@@ -218,11 +217,14 @@ function feedland_blogroll_default_options(): void {
 function feedland_get_opml_url() {
 	$options = get_option( 'feedland_blogroll_options' );
 
-	return sprintf(
-		'%sopml?screenname=%s&catname=%s',
-		trailingslashit( $options['feedland_blogroll_server'] ?: FEEDLAND_DEFAULT_SERVER ) ,
-		$options['feedland_blogroll_username'] ?: FEEDLAND_DEFAULT_USERNAME,
-		$options['feedland_blogroll_category'] ?: FEEDLAND_DEFAULT_CATEGORY
+	return add_query_arg(
+		array_filter(
+			array(
+				'screenname' => $options['feedland_blogroll_username'] ?: FEEDLAND_DEFAULT_USERNAME,
+				'catname'    => $options['feedland_blogroll_category'],
+			)
+		),
+		trailingslashit( $options['feedland_blogroll_server'] ?: FEEDLAND_DEFAULT_SERVER ) . 'opml'
 	);
 }
 
@@ -234,10 +236,13 @@ function feedland_get_opml_url() {
 function feedland_get_blogroll_url() {
 	$options = get_option( 'feedland_blogroll_options' );
 
-	return sprintf(
-		'%s?username=%s&catname=%s',
-		trailingslashit( $options['feedland_blogroll_server'] ?: FEEDLAND_DEFAULT_SERVER ) ,
-		$options['feedland_blogroll_username'] ?: FEEDLAND_DEFAULT_USERNAME,
-		$options['feedland_blogroll_category'] ?: FEEDLAND_DEFAULT_CATEGORY
+	return add_query_arg(
+		array_filter(
+			array(
+				'username' => $options['feedland_blogroll_username'] ?: FEEDLAND_DEFAULT_USERNAME,
+				'catname'  => $options['feedland_blogroll_category'],
+			)
+		),
+		trailingslashit( $options['feedland_blogroll_server'] ?: FEEDLAND_DEFAULT_SERVER )
 	);
 }

--- a/feedland-blogroll.php
+++ b/feedland-blogroll.php
@@ -27,7 +27,6 @@ define( 'FEEDLAND_BLOGROLL_PATH', plugin_dir_path( __FILE__ ) );
 
 define( 'FEEDLAND_DEFAULT_SERVER', 'https://feedland.com/' );
 define( 'FEEDLAND_DEFAULT_USERNAME', 'davewiner' );
-define( 'FEEDLAND_DEFAULT_CATEGORY', 'blogroll' );
 
 require_once 'includes/settings.php';
 require_once 'includes/self-update.php';
@@ -193,7 +192,6 @@ function feedland_blogroll_default_options(): void {
 		'feedland_blogroll_flDisplayTitle'          => '1',
 		'feedland_blogroll_server'                  => FEEDLAND_DEFAULT_SERVER,
 		'feedland_blogroll_username'                => FEEDLAND_DEFAULT_USERNAME,
-		'feedland_blogroll_category'                => FEEDLAND_DEFAULT_CATEGORY,
 		'feedland_blogroll_urlBlogrollOpml'         => feedland_get_opml_url(),
 		'feedland_blogroll_urlFeedlandViewBlogroll' => feedland_get_blogroll_url(),
 	);
@@ -213,18 +211,15 @@ function feedland_blogroll_default_options(): void {
 /**
  * Formats the Blogroll OPML URL using the user provided settings.
  *
- * @param string $category The category to use in the URL. Defaults to the `blogroll` category.
- *
  * @return string
  */
-function feedland_get_opml_url( $category = FEEDLAND_DEFAULT_CATEGORY ) {
+function feedland_get_opml_url() {
 	$options = get_option( 'feedland_blogroll_options' );
 
 	return add_query_arg(
 		array_filter(
 			array(
 				'screenname' => $options['feedland_blogroll_username'] ?: FEEDLAND_DEFAULT_USERNAME, // phpcs:ignore Universal.Operators.DisallowShortTernary.Found
-				'catname'    => $category ?: $options['feedland_blogroll_category'], // phpcs:ignore Universal.Operators.DisallowShortTernary.Found
 			)
 		),
 		FEEDLAND_DEFAULT_SERVER . 'opml'
@@ -243,7 +238,6 @@ function feedland_get_blogroll_url() {
 		array_filter(
 			array(
 				'username' => $options['feedland_blogroll_username'] ?: FEEDLAND_DEFAULT_USERNAME, // phpcs:ignore Universal.Operators.DisallowShortTernary.Found
-				'catname'  => $options['feedland_blogroll_category'],
 			)
 		),
 		FEEDLAND_DEFAULT_SERVER

--- a/feedland-blogroll.php
+++ b/feedland-blogroll.php
@@ -25,8 +25,9 @@ if ( defined( 'FEEDLAND_BLOGROLL_PATH' ) ) {
 
 define( 'FEEDLAND_BLOGROLL_PATH', plugin_dir_path( __FILE__ ) );
 
-define( 'FEEDLAND_DEFAULT_SERVER', 'https://feedland.social/' );
+define( 'FEEDLAND_DEFAULT_SERVER', 'https://feedland.com/' );
 define( 'FEEDLAND_DEFAULT_USERNAME', 'davewiner' );
+define( 'FEEDLAND_DEFAULT_CATEGORY', 'blogroll' );
 
 require_once 'includes/settings.php';
 require_once 'includes/self-update.php';
@@ -192,7 +193,7 @@ function feedland_blogroll_default_options(): void {
 		'feedland_blogroll_flDisplayTitle'          => '1',
 		'feedland_blogroll_server'                  => FEEDLAND_DEFAULT_SERVER,
 		'feedland_blogroll_username'                => FEEDLAND_DEFAULT_USERNAME,
-		'feedland_blogroll_category'                => '',
+		'feedland_blogroll_category'                => FEEDLAND_DEFAULT_CATEGORY,
 		'feedland_blogroll_urlBlogrollOpml'         => feedland_get_opml_url(),
 		'feedland_blogroll_urlFeedlandViewBlogroll' => feedland_get_blogroll_url(),
 	);
@@ -212,9 +213,11 @@ function feedland_blogroll_default_options(): void {
 /**
  * Formats the Blogroll OPML URL using the user provided settings.
  *
+ * @param string $category The category to use in the URL. Defaults to the `blogroll` category.
+ *
  * @return string
  */
-function feedland_get_opml_url( $category = '' ) {
+function feedland_get_opml_url( $category = FEEDLAND_DEFAULT_CATEGORY ) {
 	$options = get_option( 'feedland_blogroll_options' );
 
 	return add_query_arg(

--- a/feedland-blogroll.php
+++ b/feedland-blogroll.php
@@ -25,7 +25,7 @@ if ( defined( 'FEEDLAND_BLOGROLL_PATH' ) ) {
 
 define( 'FEEDLAND_BLOGROLL_PATH', plugin_dir_path( __FILE__ ) );
 
-define( 'FEEDLAND_DEFAULT_SERVER', 'https://feedland.social' );
+define( 'FEEDLAND_DEFAULT_SERVER', 'https://feedland.social/' );
 define( 'FEEDLAND_DEFAULT_USERNAME', 'davewiner' );
 
 require_once 'includes/settings.php';
@@ -214,17 +214,17 @@ function feedland_blogroll_default_options(): void {
  *
  * @return string
  */
-function feedland_get_opml_url() {
+function feedland_get_opml_url( $category = '' ) {
 	$options = get_option( 'feedland_blogroll_options' );
 
 	return add_query_arg(
 		array_filter(
 			array(
-				'screenname' => $options['feedland_blogroll_username'] ?: FEEDLAND_DEFAULT_USERNAME,
-				'catname'    => $options['feedland_blogroll_category'],
+				'screenname' => $options['feedland_blogroll_username'] ?: FEEDLAND_DEFAULT_USERNAME, // phpcs:ignore Universal.Operators.DisallowShortTernary.Found
+				'catname'    => $category ?: $options['feedland_blogroll_category'], // phpcs:ignore Universal.Operators.DisallowShortTernary.Found
 			)
 		),
-		trailingslashit( $options['feedland_blogroll_server'] ?: FEEDLAND_DEFAULT_SERVER ) . 'opml'
+		FEEDLAND_DEFAULT_SERVER . 'opml'
 	);
 }
 
@@ -239,10 +239,10 @@ function feedland_get_blogroll_url() {
 	return add_query_arg(
 		array_filter(
 			array(
-				'username' => $options['feedland_blogroll_username'] ?: FEEDLAND_DEFAULT_USERNAME,
+				'username' => $options['feedland_blogroll_username'] ?: FEEDLAND_DEFAULT_USERNAME, // phpcs:ignore Universal.Operators.DisallowShortTernary.Found
 				'catname'  => $options['feedland_blogroll_category'],
 			)
 		),
-		trailingslashit( $options['feedland_blogroll_server'] ?: FEEDLAND_DEFAULT_SERVER )
+		FEEDLAND_DEFAULT_SERVER
 	);
 }

--- a/feedland-blogroll.php
+++ b/feedland-blogroll.php
@@ -4,7 +4,7 @@
  * Description:       Show a Blogroll on your site.
  * Requires at least: 6.1
  * Requires PHP:      7.4
- * Version:           1.0.2
+ * Version:           1.1.0
  * Author:            WordPress.com Special Projects
  * Author URI:        https://wpspecialprojects.wordpress.com
  * Update URI:        https://github.com/a8cteam51/feedland-blogroll
@@ -24,6 +24,10 @@ if ( defined( 'FEEDLAND_BLOGROLL_PATH' ) ) {
 }
 
 define( 'FEEDLAND_BLOGROLL_PATH', plugin_dir_path( __FILE__ ) );
+
+define( 'FEEDLAND_DEFAULT_SERVER', 'https://feedland.social' );
+define( 'FEEDLAND_DEFAULT_USERNAME', 'davewiner' );
+define( 'FEEDLAND_DEFAULT_CATEGORY', 'blogroll' );
 
 require_once 'includes/settings.php';
 require_once 'includes/self-update.php';
@@ -148,9 +152,9 @@ function feedland_blogroll_enqueue_scripts(): void {
 		'BLOGROLL_OPTIONS',
 		array(
 			'title'                   => $options['feedland_blogroll_title'],
-			'flDisplayTitle'          => $options['feedland_blogroll_flDisplayTitle'],
-			'urlBlogrollOpml'         => $options['feedland_blogroll_urlBlogrollOpml'],
-			'urlFeedlandViewBlogroll' => $options['feedland_blogroll_urlFeedlandViewBlogroll'],
+			'flDisplayTitle'          => $options['feedland_blogroll_flDisplayTitle'] ?? false, // Prevents a warning if settings are saved and checkbox is unchecked.
+			'urlBlogrollOpml'         => feedland_get_opml_url(),
+			'urlFeedlandViewBlogroll' => feedland_get_blogroll_url(),
 			'maxItemsInBlogroll'      => 40,
 		)
 	);
@@ -187,8 +191,11 @@ function feedland_blogroll_default_options(): void {
 	$defaults = array(
 		'feedland_blogroll_title'                   => __( 'My Blogroll', 'feedland-blogroll' ),
 		'feedland_blogroll_flDisplayTitle'          => '1',
-		'feedland_blogroll_urlBlogrollOpml'         => 'https://feedland.social/opml?screenname=davewiner&catname=blogroll',
-		'feedland_blogroll_urlFeedlandViewBlogroll' => 'https://feedland.social/?username=davewiner&catname=blogroll',
+		'feedland_blogroll_server'                  => FEEDLAND_DEFAULT_SERVER,
+		'feedland_blogroll_username'                => FEEDLAND_DEFAULT_USERNAME,
+		'feedland_blogroll_category'                => FEEDLAND_DEFAULT_CATEGORY,
+		'feedland_blogroll_urlBlogrollOpml'         => feedland_get_opml_url(),
+		'feedland_blogroll_urlFeedlandViewBlogroll' => feedland_get_blogroll_url(),
 	);
 
 	$options = get_option( 'feedland_blogroll_options' );
@@ -201,4 +208,36 @@ function feedland_blogroll_default_options(): void {
 		$options = wp_parse_args( $options, $defaults );
 		update_option( 'feedland_blogroll_options', $options );
 	}
+}
+
+/**
+ * Formats the Blogroll OPML URL using the user provided settings.
+ *
+ * @return string
+ */
+function feedland_get_opml_url() {
+	$options = get_option( 'feedland_blogroll_options' );
+
+	return sprintf(
+		'%sopml?screenname=%s&catname=%s',
+		trailingslashit( $options['feedland_blogroll_server'] ?: FEEDLAND_DEFAULT_SERVER ) ,
+		$options['feedland_blogroll_username'] ?: FEEDLAND_DEFAULT_USERNAME,
+		$options['feedland_blogroll_category'] ?: FEEDLAND_DEFAULT_CATEGORY
+	);
+}
+
+/**
+ * Formats the Blogroll URL using the user provided settings.
+ *
+ * @return string
+ */
+function feedland_get_blogroll_url() {
+	$options = get_option( 'feedland_blogroll_options' );
+
+	return sprintf(
+		'%s?username=%s&catname=%s',
+		trailingslashit( $options['feedland_blogroll_server'] ?: FEEDLAND_DEFAULT_SERVER ) ,
+		$options['feedland_blogroll_username'] ?: FEEDLAND_DEFAULT_USERNAME,
+		$options['feedland_blogroll_category'] ?: FEEDLAND_DEFAULT_CATEGORY
+	);
 }

--- a/includes/self-update.php
+++ b/includes/self-update.php
@@ -1,5 +1,5 @@
 <?php
-add_filter( 'update_plugins_github.com', 'feedland_blogroll_self_update', 10, 4 );
+add_filter( 'update_plugins_github.com', 'feedland_blogroll_self_update', 10, 3 );
 
 /**
  * Check for updates to this plugin
@@ -11,7 +11,7 @@ add_filter( 'update_plugins_github.com', 'feedland_blogroll_self_update', 10, 4 
  *
  * @return array|false Array of update data or false if no update available.
  */
-function feedland_blogroll_self_update( $update, array $plugin_data, string $plugin_file, $locales ) {
+function feedland_blogroll_self_update( $update, array $plugin_data, string $plugin_file ) {
 
 	// only check this plugin
 	if ( 'feedland-blogroll/feedland-blogroll.php' !== $plugin_file ) {

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -81,7 +81,7 @@ function feedland_blogroll_settings_init(): void {
 			'label_for' => 'feedland_blogroll_flDisplayTitle',
 			'type'      => 'checkbox',
 			'name'      => 'feedland_blogroll_flDisplayTitle',
-			'class'     => 'regular-text',
+			'class'     => '',
 		)
 	);
 

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -101,20 +101,6 @@ function feedland_blogroll_settings_init(): void {
 			'description' => esc_html__( 'Username associated with the FeedLand feed you want to display on your site.', 'feedland-blogroll' ),
 		)
 	);
-
-	add_settings_field(
-		'feedland_blogroll_category',
-		__( 'Category (optional)', 'feedland-blogroll' ),
-		'feedland_blogroll_settings_field_callback',
-		'feedland_blogroll_settings',
-		'feedland_blogroll_settings_section',
-		array(
-			'label_for'   => 'feedland_blogroll_category',
-			'type'        => 'text',
-			'name'        => 'feedland_blogroll_category',
-			'class'       => 'regular-text',
-		)
-	);
 }
 
 /**
@@ -217,43 +203,6 @@ function feedland_blogroll_validate_options( array $input ): array {
 		);
 
 		$input['feedland_blogroll_username'] = FEEDLAND_DEFAULT_USERNAME;
-	}
-
-	// Validate category, since username is now validated or default.
-	$request = wp_remote_get(
-		add_query_arg(
-			array(
-				'url' => rawurlencode( feedland_get_opml_url( $input['feedland_blogroll_category'] ) ),
-			),
-			FEEDLAND_DEFAULT_SERVER . 'getfeedlistfromopml'
-		)
-	);
-
-	if ( is_wp_error( $request ) ) {
-		add_settings_error(
-			'feedland_blogroll_settings',
-			'feedland_blogroll_category',
-			esc_html__( 'There was an error communicating with the server.', 'feedland-blogroll' )
-		);
-
-		$input['feedland_blogroll_category'] = FEEDLAND_DEFAULT_CATEGORY;
-	}
-
-	$response = json_decode( wp_remote_retrieve_body( $request ), true );
-
-	// If the response contains a message, the category does not exist.
-	if ( array_key_exists( 'message', $response ) ) {
-		add_settings_error(
-			'feedland_blogroll_settings',
-			'feedland_blogroll_category',
-			sprintf(
-				/* translators: %s: Default category placeholder */
-				esc_html__( 'The user does not have that category in their feed. Using default "%s".', 'feedland-blogroll' ),
-				FEEDLAND_DEFAULT_CATEGORY
-			)
-		);
-
-		$input['feedland_blogroll_category'] = FEEDLAND_DEFAULT_CATEGORY;
 	}
 
 	return $input;

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -86,33 +86,50 @@ function feedland_blogroll_settings_init(): void {
 	);
 
 	add_settings_field(
-		'feedland_blogroll_urlBlogrollOpml',
-		__( 'Blogroll OPML URL', 'feedland-blogroll' ),
+		'feedland_blogroll_server',
+		__( 'FeedLand Server', 'feedland-blogroll' ),
 		'feedland_blogroll_settings_field_callback',
 		'feedland_blogroll_settings',
 		'feedland_blogroll_settings_section',
 		array(
-			'label_for' => 'feedland_blogroll_urlBlogrollOpml',
-			'type'      => 'url',
-			'name'      => 'feedland_blogroll_urlBlogrollOpml',
-			'class'     => 'regular-text',
+			'label_for'   => 'feedland_blogroll_server',
+			'type'        => 'url',
+			'name'        => 'feedland_blogroll_server',
+			'class'       => 'regular-text',
+			'placeholder' => FEEDLAND_DEFAULT_SERVER
 		)
 	);
 
 	add_settings_field(
-		'feedland_blogroll_urlFeedlandViewBlogroll',
-		__( 'Feedland View Blogroll URL', 'feedland-blogroll' ),
+		'feedland_blogroll_username',
+		__( 'FeedLand Username', 'feedland-blogroll' ),
 		'feedland_blogroll_settings_field_callback',
 		'feedland_blogroll_settings',
 		'feedland_blogroll_settings_section',
 		array(
-			'label_for' => 'feedland_blogroll_urlFeedlandViewBlogroll',
-			'type'      => 'url',
-			'name'      => 'feedland_blogroll_urlFeedlandViewBlogroll',
-			'class'     => 'regular-text',
+			'label_for'   => 'feedland_blogroll_username',
+			'type'        => 'text',
+			'name'        => 'feedland_blogroll_username',
+			'class'       => 'regular-text',
+			'placeholder' => FEEDLAND_DEFAULT_USERNAME,
+			'description' => esc_html( 'Username associated with the FeedLand feed you want to display on your site.', 'feedland-blogroll' ),
 		)
 	);
 
+	add_settings_field(
+		'feedland_blogroll_category',
+		__( 'Category', 'feedland-blogroll' ),
+		'feedland_blogroll_settings_field_callback',
+		'feedland_blogroll_settings',
+		'feedland_blogroll_settings_section',
+		array(
+			'label_for'   => 'feedland_blogroll_category',
+			'type'        => 'text',
+			'name'        => 'feedland_blogroll_category',
+			'class'       => 'regular-text',
+			'placeholder' => FEEDLAND_DEFAULT_CATEGORY,
+		)
+	);
 }
 
 /**
@@ -134,17 +151,18 @@ function feedland_blogroll_settings_section_callback(): void {
 function feedland_blogroll_settings_field_callback( array $args ): void {
 	$options = get_option( 'feedland_blogroll_options' );
 
-	$value = isset( $options[ $args['name'] ] ) ? $options[ $args['name'] ] : '';
+	$value = $options[ $args['name'] ] ?? '';
 
 	switch ( $args['type'] ) {
 		case 'text':
 		case 'url':
 			printf(
-				'<input type="%1$s" id="%2$s" name="feedland_blogroll_options[%2$s]" value="%3$s" class="%4$s" />',
+				'<input type="%1$s" id="%2$s" name="feedland_blogroll_options[%2$s]" value="%3$s" class="%4$s" placeholder="%5$s" />',
 				esc_attr( $args['type'] ),
 				esc_attr( $args['name'] ),
 				esc_attr( $value ),
-				esc_attr( $args['class'] )
+				esc_attr( $args['class'] ),
+				esc_attr( $args['placeholder'] ?? '' )
 			);
 			break;
 		case 'checkbox':

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -127,7 +127,7 @@ function feedland_blogroll_settings_init(): void {
 			'type'        => 'text',
 			'name'        => 'feedland_blogroll_category',
 			'class'       => 'regular-text',
-			'placeholder' => FEEDLAND_DEFAULT_CATEGORY,
+			'placeholder' => 'blogroll',
 		)
 	);
 }

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -48,7 +48,7 @@ function feedland_blogroll_settings_init(): void {
 		'feedland_blogroll_settings',
 		'feedland_blogroll_options',
 		array(
-			'sanitize_callback' => 'feedland_validate_options',
+			'sanitize_callback' => 'feedland_blogroll_validate_options',
 		)
 	);
 
@@ -98,14 +98,13 @@ function feedland_blogroll_settings_init(): void {
 			'type'        => 'text',
 			'name'        => 'feedland_blogroll_username',
 			'class'       => 'regular-text',
-			'placeholder' => FEEDLAND_DEFAULT_USERNAME,
 			'description' => esc_html__( 'Username associated with the FeedLand feed you want to display on your site.', 'feedland-blogroll' ),
 		)
 	);
 
 	add_settings_field(
 		'feedland_blogroll_category',
-		__( 'Category', 'feedland-blogroll' ),
+		__( 'Category (optional)', 'feedland-blogroll' ),
 		'feedland_blogroll_settings_field_callback',
 		'feedland_blogroll_settings',
 		'feedland_blogroll_settings_section',
@@ -114,7 +113,6 @@ function feedland_blogroll_settings_init(): void {
 			'type'        => 'text',
 			'name'        => 'feedland_blogroll_category',
 			'class'       => 'regular-text',
-			'placeholder' => 'blogroll',
 		)
 	);
 }
@@ -189,7 +187,7 @@ function feedland_blogroll_add_action_links( array $links ): array {
  *
  * @return array Validated options
  */
-function feedland_validate_options( array $input ): array {
+function feedland_blogroll_validate_options( array $input ): array {
 	$input         = array_map( 'sanitize_text_field', $input );
 	$user_endpoint = sprintf( '%1$sisuserindatabase?screenname=%2$s', FEEDLAND_DEFAULT_SERVER, $input['feedland_blogroll_username'] );
 
@@ -238,7 +236,7 @@ function feedland_validate_options( array $input ): array {
 			esc_html__( 'There was an error communicating with the server.', 'feedland-blogroll' )
 		);
 
-		$input['feedland_blogroll_category'] = '';
+		$input['feedland_blogroll_category'] = FEEDLAND_DEFAULT_CATEGORY;
 	}
 
 	$response = json_decode( wp_remote_retrieve_body( $request ), true );
@@ -248,11 +246,14 @@ function feedland_validate_options( array $input ): array {
 		add_settings_error(
 			'feedland_blogroll_settings',
 			'feedland_blogroll_category',
-			/* translators: %s: Default category placeholder */
-			esc_html__( 'The user does not have that category in their feed. Using no category to query feed.', 'feedland-blogroll' )
+			sprintf(
+				/* translators: %s: Default category placeholder */
+				esc_html__( 'The user does not have that category in their feed. Using default "%s".', 'feedland-blogroll' ),
+				FEEDLAND_DEFAULT_CATEGORY
+			)
 		);
 
-		$input['feedland_blogroll_category'] = '';
+		$input['feedland_blogroll_category'] = FEEDLAND_DEFAULT_CATEGORY;
 	}
 
 	return $input;


### PR DESCRIPTION
# Changes proposed

This PR addresses #8. On the settings page (`/wp-admin/options-general.php?page=feedland_blogroll_settings`) more options were added:

- FeedLand Server.
- FeedLand Username.
- Category.

There's a small description for username and placeholders for helping.

# Before and after screenshots

| Before | After |
|--------|--------|
| <img width="1132" alt="Screenshot 2024-04-10 at 00 52 23" src="https://github.com/a8cteam51/feedland-blogroll/assets/24195829/f0edbb41-4872-4a8d-983f-58da0e262de8"> | <img width="1132" alt="Screenshot 2024-04-10 at 00 50 40" src="https://github.com/a8cteam51/feedland-blogroll/assets/24195829/3b54c428-812c-41fb-86da-917bbeac4d14"> | 

> [!NOTE]  
> After screenshot is outdated. As per the latest couple of commits, there's no more an input for server and category. See Nick's reply: https://github.com/a8cteam51/feedland-blogroll/pull/9#issuecomment-2052081200


# Testing

- Check the settings page. 
- Add your server, username and category or leave default.

## Known issues

There's no input validation on the plugin side, i.e. we do not validate if a given server URL is in fact a FeedLand server or if the category/username exist.

A possible solution for this is:

- Validate username/feedland server/category on the FeedLand side: there's errors already being logged in the console if any of this occurs and if so, generating a message on the Blogroll section might be useful for the user.
- Logs:
  - If **username/category** is incorrect: `err.message == Can't get the feed list because there are no feeds in the OPML file.`.
  - If **server** is incorrect: `err.message == There was an error communicating with the server.`.

Or:

We could implement those checks on the plugin side by checking an endpoint first for user existence and/or category and render a message in the shortcode if not properly configured.

<details><summary>Screenshot of the rendered shortcode when improperly configured</summary>
<p>

<img width="949" alt="Screenshot 2024-04-10 at 00 55 38" src="https://github.com/a8cteam51/feedland-blogroll/assets/24195829/077d0489-2263-4560-8fdf-95d23fa34f85">

_This is using the Twenty Twenty-Three theme._

</p>
</details> 


---

> [!IMPORTANT]  
> This PR implements no mechanism for updating the default options added after a version is released, so it assumes you'll deactivate an reactivate the plugin so the new options are present.